### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with 
 	pip install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade --allow-unsafe -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "scripts": {
     "test": "tox"
   },
-  "devDependencies": [
-    "eslint==6.8.0",
-    "less",
-    "csslint"
-  ]
+  "devDependencies": {
+    "eslint": "6.8.0",
+    "less": "3.13.1",
+    "csslint": "1.0.5"
+  }
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,28 +6,27 @@
 #
 appdirs==1.4.4
     # via fs
-asgiref==3.4.1
+asgiref==3.5.2
     # via django
-django==3.2.9
+django==3.2.14
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-fs==2.4.14
+fs==2.4.16
     # via xblock
-lxml==4.6.4
+lxml==4.9.1
     # via xblock
-mako==1.1.6
+mako==1.2.1
     # via xblock-utils
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   mako
     #   xblock
 python-dateutil==2.8.2
     # via xblock
-pytz==2021.3
+pytz==2022.1
     # via
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
     # via xblock
@@ -40,17 +39,17 @@ six==1.16.0
     #   python-dateutil
 sqlparse==0.4.2
     # via django
-web-fragments==1.1.0
+web-fragments==2.0.0
     # via
     #   xblock
     #   xblock-utils
 webob==1.8.7
     # via xblock
-xblock==1.5.1
+xblock==1.6.1
     # via
     #   -r requirements/base.in
     #   xblock-utils
-xblock-utils==2.2.0
+xblock-utils==3.0.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,25 +4,21 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.1
-    # via
-    #   -r requirements/tox.txt
-    #   virtualenv
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.1.0
     # via requests
-coverage==6.1.2
+coverage==6.4.2
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci.in
-distlib==0.3.3
+distlib==0.3.5
     # via
     #   -r requirements/tox.txt
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.4.0
+filelock==3.7.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -33,7 +29,7 @@ packaging==21.3
     # via
     #   -r requirements/tox.txt
     #   tox
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -45,26 +41,25 @@ py==1.11.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pyparsing==3.0.6
+pyparsing==3.0.9
     # via
     #   -r requirements/tox.txt
     #   packaging
-requests==2.26.0
+requests==2.28.1
     # via coveralls
 six==1.16.0
     # via
     #   -r requirements/tox.txt
     #   tox
-    #   virtualenv
 toml==0.10.2
     # via
     #   -r requirements/tox.txt
     #   tox
-tox==3.24.4
+tox==3.25.1
     # via -r requirements/tox.txt
-urllib3==1.26.7
+urllib3==1.26.11
     # via requests
-virtualenv==20.10.0
+virtualenv==20.16.2
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -13,8 +13,13 @@
 
 
 # using LTS django version
-Django<3.3
+Django<4.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,4 +1,5 @@
 # Core dependencies for installing other packages
+-c constraints.txt
 
 pip
 setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.37.0
+wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==22.2.1
     # via -r requirements/pip.in
-setuptools==59.2.0
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,15 +4,23 @@
 #
 #    make upgrade
 #
-click==8.0.3
+build==0.8.0
     # via pip-tools
+click==8.1.3
+    # via pip-tools
+packaging==21.3
+    # via build
 pep517==0.12.0
-    # via pip-tools
-pip-tools==6.4.0
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip_tools.in
-tomli==1.2.2
-    # via pep517
-wheel==0.37.0
+pyparsing==3.0.9
+    # via packaging
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,56 +8,58 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
-asgiref==3.4.1
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.8.6
+astroid==2.11.7
     # via pylint
-coverage==6.1.2
+coverage==6.4.2
     # via -r requirements/test.txt
-django==3.2.9
+dill==0.3.5.1
+    # via pylint
+django==3.2.14
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
-edx-opaque-keys==2.2.2
+edx-opaque-keys==2.3.0
     # via -r requirements/test.txt
-fs==2.4.14
+fs==2.4.16
     # via
     #   -r requirements/base.txt
     #   xblock
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
-lxml==4.6.4
+lxml==4.9.1
     # via
     #   -r requirements/base.txt
     #   xblock
-mako==1.1.6
+mako==1.2.1
     # via
     #   -r requirements/base.txt
     #   xblock-utils
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   mako
     #   xblock
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
-pbr==5.8.0
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via pylint
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pylint==2.11.1
+pylint==2.14.5
     # via -r requirements/quality.in
-pymongo==3.12.1
+pymongo==3.12.3
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -65,11 +67,10 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   xblock
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
     # via
@@ -88,17 +89,19 @@ sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-toml==0.10.2
+tomli==2.0.1
     # via pylint
-typing-extensions==4.0.0
+tomlkit==0.11.1
+    # via pylint
+typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint
-web-fragments==1.1.0
+web-fragments==2.0.0
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -107,13 +110,13 @@ webob==1.8.7
     # via
     #   -r requirements/base.txt
     #   xblock
-wrapt==1.13.3
+wrapt==1.14.1
     # via astroid
-xblock==1.5.1
+xblock==1.6.1
     # via
     #   -r requirements/base.txt
     #   xblock-utils
-xblock-utils==2.2.0
+xblock-utils==3.0.0
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-coverage==6.1.2
+coverage==6.4.2
     # via -r requirements/test.in
-edx-opaque-keys==2.2.2
+edx-opaque-keys==2.3.0
     # via -r requirements/test.in
 mock==4.0.3
     # via -r requirements/test.in
-pbr==5.8.0
+pbr==5.9.0
     # via stevedore
-pymongo==3.12.1
+pymongo==3.12.3
     # via edx-opaque-keys
-stevedore==3.5.0
+stevedore==4.0.0
     # via edx-opaque-keys

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,31 +4,27 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.1
+distlib==0.3.5
     # via virtualenv
-distlib==0.3.3
-    # via virtualenv
-filelock==3.4.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
 packaging==21.3
     # via tox
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.6
+pyparsing==3.0.9
     # via packaging
 six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
+    # via tox
 toml==0.10.2
     # via tox
-tox==3.24.4
+tox==3.25.1
     # via -r requirements/tox.in
-virtualenv==20.10.0
+virtualenv==20.16.2
     # via tox


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.