### PR TITLE
feat: standardize translation directory for i18n_tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ ifeq ($(strip $(po_files)),)
 endif
 mo_files := $(patsubst %.po,%.mo,$(po_files))
 
+WORKING_DIR := submit_and_compare
+EXTRACT_DIR := $(WORKING_DIR)/conf/locale/en/LC_MESSAGES
+EXTRACTED_DJANGO := $(EXTRACT_DIR)/django-partial.po
+EXTRACTED_TEXT := $(EXTRACT_DIR)/django.po
+
 .PHONY: help
 help:  ## This.
 	@perl -ne 'print if /^[a-zA-Z_-]+:.*## .*$$/' $(MAKEFILE_LIST) \
@@ -135,3 +140,9 @@ docker_shell:  ## Drop into a shell inside the docker container
 docker_static: ; make build_docker; $(run-in-docker)  ## Compile static assets in docker container
 docker_translations: ; make build_docker; $(run-in-docker)  ## Update translation files in docker container
 docker_test: ; make build_docker; $(run-in-docker)  ## Run tests in docker container
+
+extract_translations: ## extract strings to be translated, outputting .po files
+	cd $(WORKING_DIR) && i18n_tool extract
+	mv $(EXTRACTED_DJANGO) $(EXTRACTED_TEXT)
+	sed -i'' -e 's/nplurals=INTEGER/nplurals=2/' $(EXTRACTED_TEXT)
+	sed -i'' -e 's/plural=EXPRESSION/plural=\(n != 1\)/' $(EXTRACTED_TEXT)

--- a/submit_and_compare/conf/locale/config.yaml
+++ b/submit_and_compare/conf/locale/config.yaml
@@ -1,0 +1,4 @@
+# Configuration for i18n workflow.
+
+locales:
+    - en  # English - Source Language

--- a/submit_and_compare/mixins/fragment.py
+++ b/submit_and_compare/mixins/fragment.py
@@ -22,6 +22,12 @@ class XBlockFragmentBuilderMixin:
     static_js_init = None
     template = 'view.html'
 
+    def get_i18n_service(self):
+        """
+        Get the i18n service from the runtime
+        """
+        return self.runtime.service(self, 'i18n')
+
     def provide_context(self, context):  # pragma: no cover
         """
         Build a context dictionary to render the student view
@@ -71,7 +77,7 @@ class XBlockFragmentBuilderMixin:
             rendered_template = self.loader.render_django_template(
                 template,
                 context=Context(context),
-                i18n_service=self.runtime.service(self, 'i18n'),
+                i18n_service=self.get_i18n_service(),
             )
         fragment = Fragment(rendered_template)
         for item in css:

--- a/submit_and_compare/templates/edit.html
+++ b/submit_and_compare/templates/edit.html
@@ -5,56 +5,56 @@
         
          <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label" for="submit_and_compare_edit_display_name">Display Name</label>
+                <label class="label setting-label" for="submit_and_compare_edit_display_name">{% trans "Display Name" %}</label>
                 <input class="input setting-input" id="submit_and_compare_edit_display_name" value="{{ display_name }}" type="text">
             </div>
-            <span class="tip setting-help">This name appears in the horizontal navigation at the top of the page</span>
+            <span class="tip setting-help">{% trans "This name appears in the horizontal navigation at the top of the page" %}</span>
         </li>
 
         <li class="field comp-setting-entry is-set">
           <div class="wrapper-comp-setting">
-                <label class="label setting-label" for="submit_and_compare_edit_weight">Weight</label>
+                <label class="label setting-label" for="submit_and_compare_edit_weight">{% trans "Weight" %}</label>
                 <input class="input setting-input" id="submit_and_compare_edit_weight" step="1" min="0" value="{{ weight }}" type="number">
           </div>
-          <span class="tip setting-help">This assigns an integer value representing the weight of this problem</span>
+          <span class="tip setting-help">{% trans "This assigns an integer value representing the weight of this problem" %}</span>
         </li>
 
         <li class="field comp-setting-entry is-set">
           <div class="wrapper-comp-setting">
-                <label class="label setting-label" for="submit_and_compare_edit_max_attempts">Max Attempts</label>
+                <label class="label setting-label" for="submit_and_compare_edit_max_attempts">{% trans "Max Attempts" %}</label>
                 <input class="input setting-input" id="submit_and_compare_edit_max_attempts" step="1" min="0" value="{{ max_attempts }}" type="number">
           </div>
-          <span class="tip setting-help">This assigns an integer value representing the maximum number of times a student can attempt the problem</span>
+          <span class="tip setting-help">{% trans "This assigns an integer value representing the maximum number of times a student can attempt the problem" %}</span>
         </li>
 
          <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label" for="submit_and_compare_edit_your_answer_label">Label for Student Answer</label>
+                <label class="label setting-label" for="submit_and_compare_edit_your_answer_label">{% trans "Label for Student Answer" %}</label>
                 <input class="input setting-input" id="submit_and_compare_edit_your_answer_label" value="{{ your_answer_label }}" type="text">
             </div>
-            <span class="tip setting-help">Label for the text area containing the student's answer</span>
+            <span class="tip setting-help">{% trans "Label for the text area containing the student's answer" %}</span>
         </li>
 
          <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label" for="submit_and_compare_edit_our_answer_label">Label for Expert Answer</label>
+                <label class="label setting-label" for="submit_and_compare_edit_our_answer_label">{% trans "Label for Expert Answer" %}</label>
                 <input class="input setting-input" id="submit_and_compare_edit_our_answer_label" value="{{ our_answer_label }}" type="text">
             </div>
-            <span class="tip setting-help">Label for the 'expert' answer</span>
+            <span class="tip setting-help">{% trans "Label for the 'expert' answer" %}</span>
         </li>
 
         <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label" for="submit_and_compare_edit_submit_button_label">Label for Submit Button</label>
+                <label class="label setting-label" for="submit_and_compare_edit_submit_button_label">{% trans "Label for Submit Button" %}</label>
                 <input class="input setting-input" id="submit_and_compare_edit_submit_button_label" value="{{ submit_button_label }}" type="text">
             </div>
-            <span class="tip setting-help">Label for the submit button</span>
+            <span class="tip setting-help">{% trans "Label for the submit button" %}</span>
         </li>
         
         <li class="field comp-setting-entry is-set">
           <div class="wrapper-comp-setting">
-            <label class="label setting-label" for="edit_data">Definition</label>
-            <span class="tip setting-help">The XML definition for the question and expert answer</span>
+            <label class="label setting-label" for="edit_data">{% trans "Definition" %}</label>
+            <span class="tip setting-help">{% trans "The XML definition for the question and expert answer" %}</span>
             <div class='codemirror-editor-wrapper'>
               <textarea class="block-xml-editor edit-data">{{ xml_data }}</textarea>
             </div>
@@ -66,10 +66,10 @@
     <div class="xblock-actions">
         <ul>
             <li class="action-item">
-                <a href="#" class="button action-primary action-save">Save</a>
+                <a href="#" class="button action-primary action-save">{% trans "Save" %}</a>
             </li>
             <li class="action-item">
-                <a href="#" class="button action-cancel">Cancel</a>
+                <a href="#" class="button action-cancel">{% trans "Cancel" %}</a>
             </li>
         </ul>
     </div>

--- a/submit_and_compare/tests/test_all.py
+++ b/submit_and_compare/tests/test_all.py
@@ -53,7 +53,11 @@ class SubmitAndCompareXblockTestCase(unittest.TestCase):
         """
         Checks studio view for instance variables specified by the instructor.
         """
-        studio_view_html = self.studio_view_html()
+        with mock.patch(
+            "submit_and_compare.mixins.fragment.XBlockFragmentBuilderMixin.get_i18n_service",
+            return_value=None
+        ):
+            studio_view_html = self.studio_view_html()
         self.assertIn(self.xblock.display_name, studio_view_html)
         xblock_body = get_body(
             self.xblock.question_string

--- a/submit_and_compare/tests/test_all.py
+++ b/submit_and_compare/tests/test_all.py
@@ -7,7 +7,6 @@ from xml.sax.saxutils import escape
 
 from unittest import mock
 from django.test.client import Client
-from django.utils.translation import ugettext as _
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xblock.field_data import DictFieldData
 
@@ -112,7 +111,7 @@ class SubmitAndCompareXblockTestCase(unittest.TestCase):
         self.xblock.score = 0
         self.xblock.weight = 1
         self.assertEqual(
-            _('(1 point possible)'),
+            '(1 point possible)',
             self.xblock._get_problem_progress(),
         )
 
@@ -125,7 +124,7 @@ class SubmitAndCompareXblockTestCase(unittest.TestCase):
         self.xblock.score = 0
         self.xblock.weight = 3
         self.assertEqual(
-            _('(3 points possible)'),
+            '(3 points possible)',
             self.xblock._get_problem_progress(),
         )
 
@@ -138,7 +137,7 @@ class SubmitAndCompareXblockTestCase(unittest.TestCase):
         self.xblock.score = 1
         self.xblock.weight = 1
         self.assertEqual(
-            _('(1/1 point)'),
+            '(1/1 point)',
             self.xblock._get_problem_progress(),
         )
 
@@ -151,7 +150,7 @@ class SubmitAndCompareXblockTestCase(unittest.TestCase):
         self.xblock.score = 1
         self.xblock.weight = 3
         self.assertEqual(
-            _('(3/3 points)'),
+            '(3/3 points)',
             self.xblock._get_problem_progress(),
         )
 
@@ -172,7 +171,7 @@ class SubmitAndCompareXblockTestCase(unittest.TestCase):
         self.xblock.max_attempts = 5
         self.xblock.count_attempts = 3
         self.assertEqual(
-            _('You have used 3 of 5 submissions'),
+            'You have used 3 of 5 submissions',
             self.xblock._get_used_attempts_feedback(),
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = 
 	-rrequirements/quality.txt
 commands = 
-	pycodestyle submit_and_compare/
+	pycodestyle --max-line-length=120 submit_and_compare/
 	pylint --rcfile=pylintrc submit_and_compare/
 
 [testenv:transifex]


### PR DESCRIPTION
feat: standardize translation directory for i18n_tool

This PR prepares the repository to comply with [openedx-translations](https://github.com/openedx/openedx-translations) by doing the following:

* Create `conf/locale` directory. This is the default used one in [openedx-translations](https://github.com/openedx/openedx-translations)
* Make the translation command `make extract_translations` build a file named `django.po` . This is the entry command used in [openedx-translations](https://github.com/openedx/openedx-translations)
* Remove translation in test files!
* Enable `i18n` translation in template files + fix a test that fails when `i18n` is enabled

- [x] Tested on local devstack palm to ensure that everything renders fine
- [x] ~~Tested on local devstack palm to ensure that local translation still works~~ no local translation exists in this repo

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For XBlocks:**
 - The standard translation path must be `conf/locale`. Therefore, we are creating a link from `conf/locale` to `translations` so Atlas can find the path without disrupting the current way of having translations locally within the XBlocks
 - [openedx-translations](https://github.com/openedx/openedx-translations) will have a related PR that adds the XBlock to the pipeline. This will not affect the current way of managing/updating translations
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo within the version bump
 - A notification for the community will be published to ensure that everyone knows why translations directories are removed from all repos