### PR TITLE
Remove xblock-utils package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,4 +33,7 @@ Version 1.1.0
 Version 1.2.0
 
                 Added support for django 4.2				
-                
+
+Version 1.3.0
+
+                Remove xblock-utils package and migrate to xblock.utils				

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,4 +4,3 @@
 Django
 six
 XBlock
-xblock-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,81 +8,44 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
-boto3==1.28.68
-    # via fs-s3fs
-botocore==1.31.68
-    # via
-    #   boto3
-    #   s3transfer
 django==3.2.22
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-    #   openedx-django-pyfs
 fs==2.4.16
-    # via
-    #   fs-s3fs
-    #   openedx-django-pyfs
-    #   xblock
-fs-s3fs==1.1.1
-    # via openedx-django-pyfs
-jmespath==1.0.1
-    # via
-    #   boto3
-    #   botocore
-lazy==1.6
     # via xblock
 lxml==4.9.3
     # via xblock
 mako==1.2.4
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 markupsafe==2.1.3
     # via
     #   mako
     #   xblock
-openedx-django-pyfs==3.4.0
-    # via xblock
 python-dateutil==2.8.2
-    # via
-    #   botocore
-    #   xblock
+    # via xblock
 pytz==2023.3.post1
     # via
     #   django
     #   xblock
 pyyaml==6.0.1
     # via xblock
-s3transfer==0.7.0
-    # via boto3
 simplejson==3.19.2
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 six==1.16.0
     # via
     #   -r requirements/base.in
     #   fs
-    #   fs-s3fs
     #   python-dateutil
 sqlparse==0.4.4
     # via django
 typing-extensions==4.8.0
     # via asgiref
-urllib3==1.26.18
-    # via botocore
 web-fragments==2.1.0
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 webob==1.8.7
     # via xblock
-xblock[django]==1.8.1
-    # via
-    #   -r requirements/base.in
-    #   xblock-utils
-xblock-utils==4.0.0
+xblock==1.8.1
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -18,7 +18,7 @@ distlib==0.3.7
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -57,7 +57,7 @@ tox==3.28.0
     #   -r requirements/tox.txt
 urllib3==2.0.7
     # via requests
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.41.2
+wheel==0.41.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -21,7 +21,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.2
+wheel==0.41.3
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,15 +14,6 @@ asgiref==3.7.2
     #   django
 astroid==3.0.1
     # via pylint
-boto3==1.28.68
-    # via
-    #   -r requirements/base.txt
-    #   fs-s3fs
-botocore==1.31.68
-    # via
-    #   -r requirements/base.txt
-    #   boto3
-    #   s3transfer
 coverage==7.3.2
     # via -r requirements/test.txt
 dill==0.3.7
@@ -31,30 +22,14 @@ django==3.2.22
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
-    #   openedx-django-pyfs
 edx-opaque-keys==2.5.1
     # via -r requirements/test.txt
 fs==2.4.16
     # via
     #   -r requirements/base.txt
-    #   fs-s3fs
-    #   openedx-django-pyfs
     #   xblock
-fs-s3fs==1.1.1
-    # via
-    #   -r requirements/base.txt
-    #   openedx-django-pyfs
 isort==5.12.0
     # via pylint
-jmespath==1.0.1
-    # via
-    #   -r requirements/base.txt
-    #   boto3
-    #   botocore
-lazy==1.6
-    # via
-    #   -r requirements/base.txt
-    #   xblock
 lxml==4.9.3
     # via
     #   -r requirements/base.txt
@@ -63,7 +38,6 @@ mako==1.2.4
     # via
     #   -r requirements/base.txt
     #   xblock
-    #   xblock-utils
 markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
@@ -73,10 +47,6 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.txt
-openedx-django-pyfs==3.4.0
-    # via
-    #   -r requirements/base.txt
-    #   xblock
 pbr==5.11.1
     # via
     #   -r requirements/test.txt
@@ -94,7 +64,6 @@ pymongo==3.13.0
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
-    #   botocore
     #   xblock
 pytz==2023.3.post1
     # via
@@ -105,20 +74,14 @@ pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   xblock
-s3transfer==0.7.0
-    # via
-    #   -r requirements/base.txt
-    #   boto3
 simplejson==3.19.2
     # via
     #   -r requirements/base.txt
     #   xblock
-    #   xblock-utils
 six==1.16.0
     # via
     #   -r requirements/base.txt
     #   fs
-    #   fs-s3fs
     #   python-dateutil
 sqlparse==0.4.4
     # via
@@ -140,25 +103,15 @@ typing-extensions==4.8.0
     #   astroid
     #   edx-opaque-keys
     #   pylint
-urllib3==1.26.18
-    # via
-    #   -r requirements/base.txt
-    #   botocore
 web-fragments==2.1.0
     # via
     #   -r requirements/base.txt
     #   xblock
-    #   xblock-utils
 webob==1.8.7
     # via
     #   -r requirements/base.txt
     #   xblock
-xblock[django]==1.8.1
-    # via
-    #   -r requirements/base.txt
-    #   xblock
-    #   xblock-utils
-xblock-utils==4.0.0
+xblock==1.8.1
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.7
     # via virtualenv
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   tox
     #   virtualenv
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/tox.in
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via tox

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 
 from setuptools import find_packages, setup
 
-version = '1.2.0'
+version = '1.3.0'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:

--- a/submit_and_compare/views.py
+++ b/submit_and_compare/views.py
@@ -8,7 +8,10 @@ from django.utils.translation import gettext as _
 from lxml import etree
 from six import StringIO
 from xblock.core import XBlock
-from xblockutils.resources import ResourceLoader
+try:
+    from xblock.utils.resources import ResourceLoader
+except ModuleNotFoundError:  # For backward compatibility with releases older than Quince.
+    from xblockutils.resources import ResourceLoader
 
 from .mixins.fragment import XBlockFragmentBuilderMixin
 


### PR DESCRIPTION
# Overview
ticket: https://github.com/openedx/xblock-submit-and-compare/issues/125

# Screenshot after PR implementation:

<img width="1276" alt="image" src="https://github.com/openedx/xblock-submit-and-compare/assets/25842457/aa349463-921a-499d-81c3-d35fc4b4f299">


# Test Instructions
[No special testing is required for it]
- Checkout the branch
- Install the xblock
- Test on browser

# TODO
- [x] Compile static assets
- [x] Lint all files
- [x] Pass all tests
- [x] Bump the version number in `setup.py`
- [x] Attach screenshots?
- [x] Code Reviewer 1:
- [x] Code Reviewer 2:
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
