### PR TITLE
feat!: remove Transifex calls for FC-0012 - OEP-58

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,0 @@
-[main]
-host = https://www.transifex.com
-
-[stanford-openedx-xblocks.submit-and-compare]
-file_filter = submit_and_compare/translations/<lang>/LC_MESSAGES/django.po
-source_file = submit_and_compare/translations/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,8 @@ Version 1.2.0
 Version 1.3.0
 
                 Remove xblock-utils package and migrate to xblock.utils				
+
+Version 2.0.0
+
+                Remove Transifex calls and bundled translation files for the OEP-58 proposal.
+                BREAKING CHANGE: This version breaks translations with Quince and earlier releases.

--- a/Makefile
+++ b/Makefile
@@ -92,14 +92,6 @@ translations:  ## Update translation files
 	@echo 'where `fr` is the language code.'
 	@echo
 
-.PHONY: translations_pull
-translations_pull:  ## Pull new translations from Transifex
-	tox -e transifex_pull
-
-.PHONY: translations_push
-translations_push:  ## Push translations to Transifex
-	tox -e transifex_push
-
 COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
 .PHONY: $(COMMON_CONSTRAINTS_TXT)
 $(COMMON_CONSTRAINTS_TXT):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 
 from setuptools import find_packages, setup
 
-version = '1.3.0'
+version = '2.0.0'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:

--- a/tox.ini
+++ b/tox.ini
@@ -50,10 +50,3 @@ deps =
 commands = 
     pycodestyle --max-line-length=120 submit_and_compare/
     pylint --rcfile=pylintrc submit_and_compare/
-
-[testenv:transifex]
-deps = 
-    transifex-client
-commands = 
-    tx push -s
-


### PR DESCRIPTION
Breaking change!
---

This change breaks the Jenkins transifex integration which has been deprecated in favor of the new GitHub Transifex App integration as part of [OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Changes
---

- [x] Removes direct use of `tx pull` and `tx push` commands from the [XBlock to let Open edX manage it](https://github.com/openedx/edx-platform/pull/33166).
- [x] Remove source and language translations from the repositories, hence no `.po` or `.mo` files will be committed into the repos.
- [x] Remove Transifex related `Makefile` targets and configuration files.
- [x] ~~Use the OEP-58 JavaScript translations from the Open edX platform~~ not available
- [x] ~~Remove `transifex-client` from requirements~~ not available

Merge timeline
---

This should only be merged after [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification) is fully implemented.

The timing announcement will be shared by @brian-smith-tcril on [#translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T) Open edX Slack channel.

**## Keep this pull request as a draft to prevent an accidental merge. ##**

Pre-merge checklist
---

- [ ] https://github.com/openedx/wg-translations/issues/20 is approved

References
---

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.