### PR TITLE
build: remove Arbi-BOM from tagging on upgrade PRs

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -17,8 +17,6 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'master' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
-      team_reviewers: "arbi-bom"
-      email_address: "arbi-bom@edx.org"
       send_success_notification: false
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Arbi-BOM is no longer the maintainer of this repo.

