### PR TITLE
Feat: Upgrade to django 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [django42, quality, csslint, eslint]
+        toxenv: [django42, django52, quality, csslint, eslint]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,7 @@ Version 2.1.0
 Version 3.0.0
 
 		Dropped support for Python 3.8 and added support for Python 3.11 and 3.12.
+
+Version 3.1.0
+
+                Added support for django 5.2.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 
 from setuptools import find_packages, setup
 
-version = '3.0.0'
+version = '3.1.0'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:
@@ -122,6 +122,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Topic :: Education',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = csslint,eslint,pycodestyle,pylint,py{311, 312}-django{42}
+envlist = csslint,eslint,pycodestyle,pylint,py{311, 312}-django{42, 52}
 
 [testenv]
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -rrequirements/test.txt
 commands = 
     coverage run manage.py test


### PR DESCRIPTION
Resolves [Add Django 5.2 support to xblock-submit-and-compare](https://github.com/openedx/xblock-submit-and-compare/issues/221)

## Add Django 5.2 Support
This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

### Changes Made:
- Update ci and tox files
- Ran django-upgrade to apply necessary syntax updates for Django 5.2.
- Run tests using tox command and resolved the warning
- Ensured all modifications remain backward-compatible with Django 4.2.

### django-upgrade usage:
`git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`
